### PR TITLE
Add kick-offline API and fix session cleanup

### DIFF
--- a/im-client/src/main/java/com/bx/imclient/IMClient.java
+++ b/im-client/src/main/java/com/bx/imclient/IMClient.java
@@ -107,5 +107,9 @@ public class IMClient {
         imSender.sendChatMessage(message);
     }
 
+    public void forceLogout(Long userId, Integer terminal, String deviceId) {
+        imSender.forceLogout(userId, terminal, deviceId);
+    }
+
 
 }

--- a/im-client/src/main/java/com/bx/imclient/sender/IMSender.java
+++ b/im-client/src/main/java/com/bx/imclient/sender/IMSender.java
@@ -348,4 +348,19 @@ public class IMSender {
             listenerMulticaster.multicast(IMListenerType.CHAT_MESSAGE, results);
         }
     }
+
+    public void forceLogout(Long userId, Integer terminal, String deviceId) {
+        String key = String.join(":", IMRedisKey.IM_USER_SERVER_ID, userId.toString(), terminal.toString());
+        Integer serverId = (Integer) redisMQTemplate.opsForValue().get(key);
+        if (serverId != null) {
+            String sendKey = String.join(":", IMRedisKey.IM_MESSAGE_FORCE_LOGOUT_QUEUE, serverId.toString());
+            IMRecvInfo recvInfo = new IMRecvInfo();
+            recvInfo.setCmd(IMCmdType.FORCE_LOGUT.code());
+            recvInfo.setReceivers(Collections.singletonList(new IMUserInfo(userId, terminal, deviceId)));
+            recvInfo.setServiceName(appName);
+            recvInfo.setSendResult(false);
+            recvInfo.setData("被强制下线");
+            redisMQTemplate.opsForList().rightPush(sendKey, recvInfo);
+        }
+    }
 }

--- a/im-common/src/main/java/com/bx/imcommon/contant/IMRedisKey.java
+++ b/im-common/src/main/java/com/bx/imcommon/contant/IMRedisKey.java
@@ -52,5 +52,10 @@ public final class IMRedisKey {
      */
     public static final CharSequence IM_USER_DEVICE_ID = "im:user:device_id" ;
 
+    /**
+     * 强制下线队列
+     */
+    public static final String IM_MESSAGE_FORCE_LOGOUT_QUEUE = "im:message:force_logout";
+
 
 }

--- a/im-platform/src/main/java/com/bx/implatform/controller/UserDeviceController.java
+++ b/im-platform/src/main/java/com/bx/implatform/controller/UserDeviceController.java
@@ -4,6 +4,7 @@ package com.bx.implatform.controller;
 import cn.hutool.core.util.StrUtil;
 import com.bx.imcommon.contant.IMRedisKey;
 import com.bx.imcommon.mq.RedisMQTemplate;
+import com.bx.imclient.IMClient;
 import com.bx.implatform.entity.UserDevice;
 import com.bx.implatform.result.Result;
 import com.bx.implatform.result.ResultUtils;
@@ -36,6 +37,8 @@ public class UserDeviceController {
     private final UserDeviceService userDeviceService;
 
     private final RedisMQTemplate redisMQTemplate;
+
+    private final IMClient imClient;
     @Operation(summary = "用户登录设备列表", description = "用户登录设备列表")
     @GetMapping("/list")
     public Result<UserDeviceVo> getLoginDevices() {
@@ -78,6 +81,19 @@ public class UserDeviceController {
         result.setNowDevice(nowVo);
         result.setOtherDeviceList(otherVos);
         return ResultUtils.success(result);
+    }
+
+    @Operation(summary = "踢设备下线", description = "踢指定设备下线")
+    @GetMapping("/kick")
+    public Result<Void> kickDevice(String deviceId) {
+        UserSession session = SessionContext.getSession();
+        Long userId = session.getUserId();
+        UserDevice device = userDeviceService.findByUserIdAndDeviceId(userId, deviceId);
+        if (device != null) {
+            Integer terminal = Integer.valueOf(device.getPlatform());
+            imClient.forceLogout(userId, terminal, deviceId);
+        }
+        return ResultUtils.success();
     }
 
 

--- a/im-server/src/main/java/com/bx/imserver/netty/IMChannelHandler.java
+++ b/im-server/src/main/java/com/bx/imserver/netty/IMChannelHandler.java
@@ -74,20 +74,23 @@ public class IMChannelHandler extends SimpleChannelInboundHandler<IMSendInfo> {
 
             ChannelHandlerContext context = UserChannelCtxMap.getChannelCtx(userId, terminal, deviceId);
             if (context != null && ctx.channel().id().equals(context.channel().id())) {
-                UserChannelCtxMap.removeChannelCtx(userId, terminal, null);
+                UserChannelCtxMap.removeChannelCtx(userId, terminal, deviceId);
 
                 RedisMQTemplate redisTemplate = SpringContextHolder.getBean(RedisMQTemplate.class);
-                String key = String.join(":", IMRedisKey.IM_USER_SERVER_ID, userId.toString(), terminal.toString());
+                String deviceKey = String.join(":", IMRedisKey.IM_USER_DEVICE_ID, userId.toString(), terminal.toString());
 
                 try {
-                    redisTemplate.delete(key);
-                    IMUserEvent event = new IMUserEvent();
-                    event.setEventType(IMEventType.OFFLINE.code());
-                    event.setUserInfo(new IMUserInfo(userId, terminal));
-                    event.setExtra(true);
-                    redisTemplate.opsForList().rightPush(IMRedisKey.IM_USER_EVENT_QUEUE, event);
-                    String deviceKey = String.join(":", IMRedisKey.IM_USER_DEVICE_ID, userId.toString(), terminal.toString());
                     redisTemplate.opsForSet().remove(deviceKey, deviceId);
+                    Long size = redisTemplate.opsForSet().size(deviceKey);
+                    if (size == null || size == 0) {
+                        String key = String.join(":", IMRedisKey.IM_USER_SERVER_ID, userId.toString(), terminal.toString());
+                        redisTemplate.delete(key);
+                        IMUserEvent event = new IMUserEvent();
+                        event.setEventType(IMEventType.OFFLINE.code());
+                        event.setUserInfo(new IMUserInfo(userId, terminal));
+                        event.setExtra(true);
+                        redisTemplate.opsForList().rightPush(IMRedisKey.IM_USER_EVENT_QUEUE, event);
+                    }
                 } catch (Exception e) {
                     log.error("handlerRemoved Redis操作异常，userId={}, terminal={}, deviceId={}", userId, terminal, deviceId, e);
                 }

--- a/im-server/src/main/java/com/bx/imserver/netty/processor/ForceLogoutProcessor.java
+++ b/im-server/src/main/java/com/bx/imserver/netty/processor/ForceLogoutProcessor.java
@@ -1,0 +1,53 @@
+package com.bx.imserver.netty.processor;
+
+import com.bx.imcommon.contant.IMRedisKey;
+import com.bx.imcommon.enums.IMCmdType;
+import com.bx.imcommon.enums.IMEventType;
+import com.bx.imcommon.model.*;
+import com.bx.imcommon.mq.RedisMQTemplate;
+import com.bx.imserver.netty.UserChannelCtxMap;
+import io.netty.channel.ChannelHandlerContext;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ForceLogoutProcessor extends AbstractMessageProcessor<IMRecvInfo> {
+
+    private final RedisMQTemplate redisMQTemplate;
+
+    @Override
+    public void process(IMRecvInfo recvInfo) {
+        IMUserInfo receiver = recvInfo.getReceivers().get(0);
+        Long userId = receiver.getId();
+        Integer terminal = receiver.getTerminal();
+        String deviceId = receiver.getDeviceId();
+        ChannelHandlerContext ctx = UserChannelCtxMap.getChannelCtx(userId, terminal, deviceId);
+        if (ctx != null) {
+            IMSendInfo<Object> sendInfo = new IMSendInfo<>();
+            sendInfo.setCmd(IMCmdType.FORCE_LOGUT.code());
+            sendInfo.setData(recvInfo.getData());
+            ctx.channel().writeAndFlush(sendInfo);
+            ctx.channel().close();
+        }
+        UserChannelCtxMap.removeChannelCtx(userId, terminal, deviceId);
+        try {
+            String deviceKey = String.join(":", IMRedisKey.IM_USER_DEVICE_ID, userId.toString(), terminal.toString());
+            redisMQTemplate.opsForSet().remove(deviceKey, deviceId);
+            Long size = redisMQTemplate.opsForSet().size(deviceKey);
+            if (size == null || size == 0) {
+                String key = String.join(":", IMRedisKey.IM_USER_SERVER_ID, userId.toString(), terminal.toString());
+                redisMQTemplate.delete(key);
+                IMUserEvent event = new IMUserEvent();
+                event.setEventType(IMEventType.OFFLINE.code());
+                event.setUserInfo(new IMUserInfo(userId, terminal));
+                event.setExtra(true);
+                redisMQTemplate.opsForList().rightPush(IMRedisKey.IM_USER_EVENT_QUEUE, event);
+            }
+        } catch (Exception e) {
+            log.error("forceLogout redis error,userId={},terminal={},deviceId={}", userId, terminal, deviceId, e);
+        }
+    }
+}

--- a/im-server/src/main/java/com/bx/imserver/netty/processor/ProcessorFactory.java
+++ b/im-server/src/main/java/com/bx/imserver/netty/processor/ProcessorFactory.java
@@ -12,6 +12,7 @@ public class ProcessorFactory {
             case PRIVATE_MESSAGE->SpringContextHolder.getApplicationContext().getBean(PrivateMessageProcessor.class);
             case GROUP_MESSAGE->SpringContextHolder.getApplicationContext().getBean(GroupMessageProcessor.class);
             case SYSTEM_MESSAGE->SpringContextHolder.getApplicationContext().getBean(SystemMessageProcessor.class);
+            case FORCE_LOGUT -> SpringContextHolder.getApplicationContext().getBean(ForceLogoutProcessor.class);
             case CHAT_MESSAGE ->SpringContextHolder.getApplicationContext().getBean(ChatMessageProcessor.class);
             default -> null;
         };

--- a/im-server/src/main/java/com/bx/imserver/task/PullForceLogoutTask.java
+++ b/im-server/src/main/java/com/bx/imserver/task/PullForceLogoutTask.java
@@ -1,0 +1,22 @@
+package com.bx.imserver.task;
+
+import com.bx.imcommon.contant.IMRedisKey;
+import com.bx.imcommon.enums.IMCmdType;
+import com.bx.imcommon.model.IMRecvInfo;
+import com.bx.imcommon.mq.RedisMQListener;
+import com.bx.imserver.netty.processor.AbstractMessageProcessor;
+import com.bx.imserver.netty.processor.ProcessorFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RedisMQListener(queue = IMRedisKey.IM_MESSAGE_FORCE_LOGOUT_QUEUE, batchSize = 10)
+public class PullForceLogoutTask extends AbstractPullMessageTask<IMRecvInfo> {
+
+    @Override
+    public void onMessage(IMRecvInfo recvInfo) {
+        AbstractMessageProcessor processor = ProcessorFactory.createProcessor(IMCmdType.FORCE_LOGUT);
+        processor.process(recvInfo);
+    }
+}


### PR DESCRIPTION
## Summary
- add a new `/user/login/device/kick` endpoint to forcibly disconnect a device
- implement ForceLogoutProcessor and queue to handle logout messages
- update channel cleanup logic to remove device-specific entries
- extend IMClient/IMSender to support force logout
- define new Redis key `IM_MESSAGE_FORCE_LOGOUT_QUEUE`

## Testing
- `mvn -q -DskipTests install` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a76cd7e748331af37ce620dce28be